### PR TITLE
Remove redundant repositories from build.gradle's

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,8 @@ android {
 
 
 repositories {
+  google()
+  jcenter()
   maven {
     url 'https://sdk.squareup.com/public/android'
   }
@@ -41,6 +43,5 @@ dependencies {
   implementation "com.android.support:design:$supportLibraryVersion"
   implementation 'com.android.support.constraint:constraint-layout:1.1.3'
   // Play Services Wallet 16.0.1 was published with dependencies on maps & identities 16.0.0.
-  //noinspection GradleCompatible
   implementation 'com.google.android.gms:play-services-wallet:16.0.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,14 +15,6 @@ buildscript {
   }
 }
 
-allprojects {
-  repositories {
-    mavenLocal()
-    google()
-    jcenter()
-  }
-}
-
 task clean(type: Delete) {
   delete rootProject.buildDir
 }


### PR DESCRIPTION
Instead of setting repositories for all modules when we only have one, set the repositories on the one module.

Also, remove `mavenLocal` from the dependencies as we don't require anything from it (if we're doing everything right).