### PR TITLE
Bump Gradle, AGP, and Retrofit

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,8 +36,8 @@ dependencies {
   def inAppPaymentsSdkVersion = '1.0.3'
   implementation "com.squareup.sdk.in-app-payments:card-entry:$inAppPaymentsSdkVersion"
   implementation "com.squareup.sdk.in-app-payments:google-pay:$inAppPaymentsSdkVersion"
-  implementation 'com.squareup.retrofit2:retrofit:2.4.0'
-  implementation 'com.squareup.retrofit2:converter-moshi:2.4.0'
+  implementation 'com.squareup.retrofit2:retrofit:2.5.0'
+  implementation 'com.squareup.retrofit2:converter-moshi:2.5.0'
   def supportLibraryVersion = '27.1.1'
   implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
   implementation "com.android.support:design:$supportLibraryVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.1'
+    classpath 'com.android.tools.build:gradle:3.3.1'
 
 
     // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Dec 07 10:28:06 PST 2018
+#Tue Feb 19 14:26:29 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
Android Studios will prompt the developers to bump the Gradle and AGP versions unless we do so preemptively. While we're here, let's bump Retrofit.