### PR TITLE
Update to 1.1.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-  def inAppPaymentsSdkVersion = '1.0.3'
+  def inAppPaymentsSdkVersion = '1.1.0'
   implementation "com.squareup.sdk.in-app-payments:card-entry:$inAppPaymentsSdkVersion"
   implementation "com.squareup.sdk.in-app-payments:google-pay:$inAppPaymentsSdkVersion"
   implementation 'com.squareup.retrofit2:retrofit:2.5.0'


### PR DESCRIPTION
The SDK allows developers to hide the postal/ZIP code fields.