### PR TITLE
Update Gradle and stop using "NotNull"

### DIFF
--- a/app/src/main/java/com/example/supercookie/ChargeCall.java
+++ b/app/src/main/java/com/example/supercookie/ChargeCall.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import okhttp3.ResponseBody;
-import org.jetbrains.annotations.NotNull;
 import retrofit2.Callback;
 import retrofit2.Converter;
 import retrofit2.Response;
@@ -105,7 +104,7 @@ public class ChargeCall implements Call<ChargeResult> {
     return call.isCanceled();
   }
 
-  @NotNull
+  @NonNull
   @Override
   public Call<ChargeResult> clone() {
     return factory.create(nonce);

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.3.1'
+    classpath 'com.android.tools.build:gradle:3.4.1'
 
 
     // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 19 14:26:29 PST 2019
+#Thu Jun 13 14:20:18 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
We want to use "NonNull" instead of "NotNull".

@bobbilee19 found this "NotNull" bug when going through a setup with the Android Studio recommended version of Gradle.