### PR TITLE
Bump IAP SDK to 1.6.8 and show version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 #  In-App Payments Quick Start Sample Android Application
 
+## Supported SDK version
+
+* In-App Payments SDK: `1.6.8`
+
 Follow the [In-App Payments Quick Start Guide](https://docs.connect.squareup.com/payments/in-app-payments-sdk/quickstart/start) to take payments in an app running on a buyer's personal mobile device.
 
 **Note:** When testing the quick start in the Square Sandbox, be sure to use the [Sandbox test values](https://developer.squareup.com/docs/testing/test-values#successstates)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
   implementation 'com.squareup.retrofit2:retrofit:2.9.0'
   implementation 'com.squareup.okhttp3:logging-interceptor:4.5.0'
 
-  def inAppPaymentsSdkVersion = '1.6.7'
+  def inAppPaymentsSdkVersion = '1.6.8'
   implementation "com.squareup.sdk.in-app-payments:card-entry:$inAppPaymentsSdkVersion"
   implementation "com.squareup.sdk.in-app-payments:google-pay:$inAppPaymentsSdkVersion"
 


### PR DESCRIPTION
## Summary
- Bump In-App Payments SDK from `1.6.7` to `1.6.8` in `app/build.gradle`
- Add SDK version section to README so the current version is obvious at a glance

## Test plan
- [x] Verify the app builds with the new SDK version

🤖 Generated with [Claude Code](https://claude.com/claude-code)