### PR TITLE
Update In-App Payments SDK to 1.6.9

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-  compileSdk = 34
+  compileSdk = 36
   namespace = "com.example.supercookie"
   buildFeatures {
     buildConfig = true
@@ -11,7 +11,7 @@ android {
   defaultConfig {
     applicationId "com.example.supercookie"
     minSdkVersion 28
-    targetSdkVersion 33
+    targetSdkVersion 36
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -26,6 +26,12 @@ android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_17
     targetCompatibility JavaVersion.VERSION_17
+  }
+
+  packagingOptions {
+    resources {
+      excludes += 'META-INF/versions/9/OSGI-INF/MANIFEST.MF'
+    }
   }
 }
 
@@ -50,9 +56,10 @@ dependencies {
   implementation 'com.squareup.retrofit2:retrofit:2.9.0'
   implementation 'com.squareup.okhttp3:logging-interceptor:4.5.0'
 
-  def inAppPaymentsSdkVersion = '1.6.8'
+  def inAppPaymentsSdkVersion = '1.6.9'
   implementation "com.squareup.sdk.in-app-payments:card-entry:$inAppPaymentsSdkVersion"
   implementation "com.squareup.sdk.in-app-payments:google-pay:$inAppPaymentsSdkVersion"
+  implementation "com.squareup.sdk.in-app-payments:buyer-verification:$inAppPaymentsSdkVersion"
 
   androidTestImplementation 'androidx.test:runner:1.4.0'
 }

--- a/app/src/main/java/com/example/supercookie/CheckoutActivity.java
+++ b/app/src/main/java/com/example/supercookie/CheckoutActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.Html;
+import android.util.Log;
 import android.view.View;
 
 import androidx.appcompat.app.AlertDialog;
@@ -19,13 +20,25 @@ import com.google.android.gms.wallet.PaymentsClient;
 import com.google.android.gms.wallet.TransactionInfo;
 import com.google.android.gms.wallet.Wallet;
 import com.google.android.gms.wallet.WalletConstants;
+import java.util.Collections;
+import sqip.BuyerAction;
+import sqip.BuyerVerification;
 import sqip.CardEntry;
+import sqip.Contact;
+import sqip.Country;
+import sqip.Currency;
 import sqip.GooglePay;
 import sqip.InAppPaymentsSdk;
+import sqip.Money;
+import sqip.SquareIdentifier;
+import sqip.VerificationParameters;
 
 public class CheckoutActivity extends AppCompatActivity {
 
   private static final int LOAD_PAYMENT_DATA_REQUEST_CODE = 1;
+  // Distinct from CardEntry.DEFAULT_CARD_ENTRY_REQUEST_CODE so we can tell the
+  // verification card entry flow apart from the regular buy flow.
+  private static final int VERIFY_CARD_ENTRY_REQUEST_CODE = 52789;
 
   private final Handler handler = new Handler(Looper.getMainLooper());
 
@@ -57,10 +70,21 @@ public class CheckoutActivity extends AppCompatActivity {
 
     View buyButton = findViewById(R.id.buy_button);
     buyButton.setOnClickListener(v -> {
-      if (InAppPaymentsSdk.INSTANCE.getSquareApplicationId().equals("REPLACE_ME")) {
+      if (InAppPaymentsSdk.getSquareApplicationId().equals("REPLACE_ME")) {
         showMissingSquareApplicationIdDialog();
       } else {
         showOrderSheet();
+      }
+    });
+
+    View verifyButton = findViewById(R.id.verify_button);
+    verifyButton.setOnClickListener(v -> {
+      if (InAppPaymentsSdk.getSquareApplicationId().equals("REPLACE_ME")) {
+        showMissingSquareApplicationIdDialog();
+      } else if (!ConfigHelper.locationIdSet()) {
+        showLocationIdNotSet();
+      } else {
+        startVerifyCardEntryActivity();
       }
     });
   }
@@ -79,6 +103,31 @@ public class CheckoutActivity extends AppCompatActivity {
 
   private void startCardEntryActivity() {
     CardEntry.startCardEntryActivity(this);
+  }
+
+  private void startVerifyCardEntryActivity() {
+    CardEntry.startCardEntryActivity(this, true, VERIFY_CARD_ENTRY_REQUEST_CODE);
+  }
+
+  private void verifyBuyer(String nonce) {
+    // Mock cardholder contact details, matching the fake persona on the order sheet.
+    Contact contact = new Contact.Builder()
+        .familyName("Cookie")
+        .email("crunch.cookie@example.com")
+        .addressLines(Collections.singletonList("1455 Market Street"))
+        .city("San Francisco")
+        .region("CA")
+        .postalCode("94103")
+        .countryCode(Country.US)
+        .build("Crunch");
+
+    VerificationParameters verificationParameters = new VerificationParameters(
+        nonce,
+        new BuyerAction.Charge(new Money(100, Currency.USD)),
+        new SquareIdentifier.LocationToken(ConfigHelper.SQUARE_LOCATION_ID),
+        contact);
+
+    BuyerVerification.verify(this, verificationParameters);
   }
 
   private void startGooglePayActivity() {
@@ -112,19 +161,43 @@ public class CheckoutActivity extends AppCompatActivity {
   @Override
   protected void onActivityResult(int requestCode, int resultCode, Intent data) {
     super.onActivityResult(requestCode, resultCode, data);
-    CardEntry.handleActivityResult(data, cardEntryActivityResult -> {
-      if (cardEntryActivityResult.isSuccess()) {
-        if (!ConfigHelper.serverHostSet()) {
-          showServerHostNotSet();
-        } else {
-          showSuccessCharge();
+    if (requestCode == CardEntry.DEFAULT_CARD_ENTRY_REQUEST_CODE) {
+      CardEntry.handleActivityResult(data, cardEntryActivityResult -> {
+        if (cardEntryActivityResult.isSuccess()) {
+          if (!ConfigHelper.serverHostSet()) {
+            showServerHostNotSet();
+          } else {
+            showSuccessCharge();
+          }
+        } else if (cardEntryActivityResult.isCanceled()) {
+          Resources res = getResources();
+          int delayMs = res.getInteger(R.integer.card_entry_activity_animation_duration_ms);
+          handler.postDelayed(this::showOrderSheet, delayMs);
         }
-      } else if (cardEntryActivityResult.isCanceled()) {
-        Resources res = getResources();
-        int delayMs = res.getInteger(R.integer.card_entry_activity_animation_duration_ms);
-        handler.postDelayed(this::showOrderSheet, delayMs);
-      }
-    });
+      });
+    }
+
+    if (requestCode == VERIFY_CARD_ENTRY_REQUEST_CODE) {
+      CardEntry.handleActivityResult(data, cardEntryActivityResult -> {
+        if (cardEntryActivityResult.isSuccess()) {
+          verifyBuyer(cardEntryActivityResult.getSuccessValue().getNonce());
+        }
+      });
+    }
+
+    if (requestCode == BuyerVerification.DEFAULT_BUYER_VERIFICATION_REQUEST_CODE) {
+      BuyerVerification.handleActivityResult(data, result -> {
+        if (result.isSuccess()) {
+          showVerificationSuccess(result.getSuccessValue().getVerificationToken(),
+              result.getSuccessValue().getHasChallengedUser());
+        } else if (result.isError()) {
+          showVerificationError(result.getErrorValue().getCode() + "\n"
+              + result.getErrorValue().getMessage() + "\n"
+              + "debugCode: " + result.getErrorValue().getDebugCode() + "\n"
+              + "debugMessage: " + result.getErrorValue().getDebugMessage());
+        }
+      });
+    }
 
     if (requestCode == LOAD_PAYMENT_DATA_REQUEST_CODE) {
       handleGooglePayActivityResult(resultCode, data);
@@ -167,6 +240,22 @@ public class CheckoutActivity extends AppCompatActivity {
 
   public void showServerHostNotSet() {
     showOkDialog(R.string.server_host_not_set_title, Html.fromHtml(getString(R.string.server_host_not_set_message)));
+  }
+
+  private void showLocationIdNotSet() {
+    showOkDialog(R.string.location_id_not_set_title, Html.fromHtml(getString(R.string.location_id_not_set_message)));
+  }
+
+  private void showVerificationSuccess(String verificationToken, boolean hasChallengedUser) {
+    Log.i("BuyerVerification",
+        "token: " + verificationToken + ", hasChallengedUser: " + hasChallengedUser);
+    showOkDialog(R.string.verification_success_title,
+        "token: " + verificationToken + "\nhasChallengedUser: " + hasChallengedUser);
+  }
+
+  private void showVerificationError(String message) {
+    Log.i("BuyerVerification", message);
+    showOkDialog(R.string.verification_error_title, message);
   }
 
   private void showMerchantIdNotSet() {

--- a/app/src/main/java/com/example/supercookie/ConfigHelper.java
+++ b/app/src/main/java/com/example/supercookie/ConfigHelper.java
@@ -13,11 +13,17 @@ import retrofit2.converter.moshi.MoshiConverterFactory;
 public class ConfigHelper {
 
   public static final String GOOGLE_PAY_MERCHANT_ID = "REPLACE_ME";
+  // Location ID matching sqip.SQUARE_APPLICATION_ID, used for buyer verification.
+  public static final String SQUARE_LOCATION_ID = "REPLACE_ME";
   private static final String CHARGE_SERVER_HOST = "REPLACE_ME";
   private static final String CHARGE_SERVER_URL = "https://" + CHARGE_SERVER_HOST + "/";
 
   public static boolean serverHostSet() {
     return !CHARGE_SERVER_HOST.equals("REPLACE_ME");
+  }
+
+  public static boolean locationIdSet() {
+    return !SQUARE_LOCATION_ID.equals("REPLACE_ME");
   }
 
   public static boolean merchantIdSet() {

--- a/app/src/main/res/layout/activity_cookie.xml
+++ b/app/src/main/res/layout/activity_cookie.xml
@@ -51,5 +51,13 @@
         android:text="@string/buy_button"
         />
 
+    <Button
+        android:id="@+id/verify_button"
+        android:layout_marginTop="8dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/verify_button"
+        />
+
   </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,4 +24,9 @@
   <string name="super_cookie">Super Cookie</string>
   <string name="total">Total</string>
   <string name="unsuccessful_order">Your order was not successful</string>
+  <string name="verify_button">Verify</string>
+  <string name="verification_success_title">Buyer verification succeeded</string>
+  <string name="verification_error_title">Buyer verification failed</string>
+  <string name="location_id_not_set_title">Missing Square Location ID</string>
+  <string name="location_id_not_set_message"><![CDATA[To verify a buyer, replace <b>ConfigHelper.SQUARE_LOCATION_ID</b> with a location ID matching your Square Application ID.]]></string>
 </resources>


### PR DESCRIPTION
- Bump the version to 1.6.9
- Update `targetSdkVersion` and `compileSdk` to `36`
- Add Buyer Verification flow to test verifying the card token